### PR TITLE
Enforce required Java version during build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <gpg.plugin.version>1.5</gpg.plugin.version>
         <nexus.staging.plugin.version>1.6.2</nexus.staging.plugin.version>
         <enforcer.plugin.version>1.3.1</enforcer.plugin.version>
+        <require.java.version>1.5.0+</require.java.version>
     </properties>
 
     <distributionManagement>
@@ -139,7 +140,7 @@
                     <version>${enforcer.plugin.version}</version>
                     <executions>
                         <execution>
-                            <id>enforce-override</id>
+                            <id>default-enforce</id>
                             <phase>validate</phase>
                             <goals>
                                 <goal>enforce</goal>
@@ -161,6 +162,9 @@
                                             connection
                                             (project.scm.connection)</message>
                                     </evaluateBeanshell>
+                                    <requireJavaVersion>
+                                        <version>${require.java.version}</version>
+                                    </requireJavaVersion>
                                 </rules>
                             </configuration>
                         </execution>


### PR DESCRIPTION
Note: default matches Maven defaults for maven.compiler.source and maven.compiler.target (1.5).