### PR TITLE
Add contributor information and CLA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,13 @@
 
 We welcome contributions from the community and love getting help from people who want to make this project better.
 
+## Contributor License Agreement (CLA)
+Before submitting your first pull request, you must [sign the sign the individual Contributor License Agreement](https://docs.google.com/a/kaazing.com/forms/d/1zdORRzO4bDAPqXN1iD1HZ-jtD71I1K21D5Dktcv1n8k/viewform).
+
+This only has to be done once as it covers all of our GitHub repositories. It's quick and easy, and should only take you a minute.
+
 ## How to submit a pull request
 
-All changes must come through a pull request from a forked repository. Please don't commit directly into this repo.
+All changes must come through a pull request from a forked repository. Submit pull requests to the `develop` branch, as we are fans of the git flow workflow model.
 
-Please make sure that your branch builds successfully before issuing a pull request. This ensures that all the tests passed, the code is formatted correctly, etc.
-
-## Contributor License Agreement (CLA)
-Before submitting your first pull request, you must first [sign the sign the individual Contributor License Agreement](https://www.clahub.com/agreements/zimmerboy/AwesomeDemo).
-
-This only has to be done once. It's quick and easy, and should only take you a minute.
+Make sure that your branch builds successfully prior to issuing a pull request. This ensures that all the tests passed, the code is formatted correctly, etc.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+We welcome contributions from the community and love getting help from people who want to make this project better.
+
+## How to submit a pull request
+
+All changes must come through a pull request from a forked repository. Please don't commit directly into this repo.
+
+Please make sure that your branch builds successfully before issuing a pull request. This ensures that all the tests passed, the code is formatted correctly, etc.
+
+## Contributor License Agreement (CLA)
+Before submitting your first pull request, you must first [sign the sign the individual Contributor License Agreement](https://www.clahub.com/agreements/zimmerboy/AwesomeDemo).
+
+This only has to be done once. It's quick and easy, and should only take you a minute.


### PR DESCRIPTION
Looking for input for everything above the **Contributor License Agreement (CLA)** heading.

Also, the link for the CLA agreement is a placeholder. The real link will need to be created by our Github superuser, which I can help them with.