### PR TITLE
Fixes for animal sniffer plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <require.java.version>1.5.0+</require.java.version>
         <animal.sniffer.version>1.14</animal.sniffer.version>
         <animal.sniffer.plugin.version>${animal.sniffer.version}</animal.sniffer.plugin.version>
-        <animal.sniffer.signature.groupId>org.codehaus.mojo.signature</animal.sniffer.signature.groupId>
+        <animal.sniffer.signature.groupId>org.kaazing.mojo.signature</animal.sniffer.signature.groupId>
         <animal.sniffer.signature.artifactId>java18</animal.sniffer.signature.artifactId>
         <animal.sniffer.signature.version>1.0</animal.sniffer.signature.version>
         <animal.sniffer.skip>false</animal.sniffer.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,12 @@
         <nexus.staging.plugin.version>1.6.2</nexus.staging.plugin.version>
         <enforcer.plugin.version>1.3.1</enforcer.plugin.version>
         <require.java.version>1.5.0+</require.java.version>
-        <animal.sniffer.version>1.13</animal.sniffer.version>
+        <animal.sniffer.version>1.14</animal.sniffer.version>
         <animal.sniffer.plugin.version>${animal.sniffer.version}</animal.sniffer.plugin.version>
         <animal.sniffer.signature.groupId>org.codehaus.mojo.signature</animal.sniffer.signature.groupId>
-        <animal.sniffer.signature.artifactId>java15</animal.sniffer.signature.artifactId>
+        <animal.sniffer.signature.artifactId>java18</animal.sniffer.signature.artifactId>
         <animal.sniffer.signature.version>1.0</animal.sniffer.signature.version>
+        <animal.sniffer.skip>false</animal.sniffer.skip>
         <lifecycle.mapping.plugin.version>1.0.0</lifecycle.mapping.plugin.version>
     </properties>
 
@@ -170,6 +171,7 @@
                                     <artifactId>${animal.sniffer.signature.artifactId}</artifactId>
                                     <version>${animal.sniffer.signature.version}</version>
                                 </signature>
+                                <skip>${animal.sniffer.skip}</skip>
                             </configuration>
                         </execution>
                     </executions>


### PR DESCRIPTION
Addressing https://github.com/kaazing/community/issues/24.  A java18 signature artifact was generated to be used for animal sniffer such that class files compiled to target 1.8 can be sniffed.  Upgrade to 1.14 of the animal sniffer plugin to get some fixes.  Also add in the ability to skip the check if required.