### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,9 +126,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>${failsafe.plugin.version}</version>
-                    <configuration>
-                        <skipTests>${skipITs}</skipTests>
-                    </configuration>
                     <executions>
                         <execution>
                             <goals>


### PR DESCRIPTION
Removed skipTests configuration of failsafe as by default skipTests and skipITs should both skip the integration tests.  https://maven.apache.org/surefire/maven-failsafe-plugin/integration-test-mojo.html.
