### PR TITLE
Revert "Update pom.xml"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>${failsafe.plugin.version}</version>
+                    <configuration>
+                        <skipTests>${skipITs}</skipTests>
+                    </configuration>
                     <executions>
                         <execution>
                             <goals>


### PR DESCRIPTION
Reverts kaazing/community#32 People seem to be using this feature even though it isn't the default for failsafe